### PR TITLE
context

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,17 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(App());
+}
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: MyFirstStatefulWidget(),
+      title: 'Some title',
+    );
+  }
 }
 
 class MyApp extends StatelessWidget {
@@ -21,11 +31,13 @@ class MyApp extends StatelessWidget {
 
 class MyFirstStatelessWidget extends StatelessWidget {
   int _buildCallingCounter = 0;
+  // Context вне области видимости и не является переменной класса
+  // Type getContextRuntimeType() => context.runtimeType; //Error: The getter 'context' isn't defined for the class 'MyFirstStatelessWidget'.
 
   @override
   Widget build(BuildContext context) {
     _buildCallingCounter++;
-    print('Метод build был вызван $_buildCallingCounter раз(а)'); //Всегда 1, Stateless пересоздается при hotreload.
+    print('Метод build был вызван $_buildCallingCounter раз(а)');
 
     return Container(
       child: Center(
@@ -35,6 +47,7 @@ class MyFirstStatelessWidget extends StatelessWidget {
   }
 }
 
+
 class MyFirstStatefulWidget extends StatefulWidget {
   @override
   _MyFirstStatefulWidgetState createState() => _MyFirstStatefulWidgetState();
@@ -43,10 +56,14 @@ class MyFirstStatefulWidget extends StatefulWidget {
 class _MyFirstStatefulWidgetState extends State<MyFirstStatefulWidget> {
   int _buildCallingCounter = 0;
 
+  // State реализует get context, отработает без проблем
+  Type getContextRuntimeType() => context.runtimeType;
+
   @override
   Widget build(BuildContext context) {
     _buildCallingCounter++;
     print('Метод build был вызван $_buildCallingCounter раз(а)'); //Счетчик увеличивается при хотрелоад, выводится верное значение, у Stateful состояние живёт дольше виджета и при перерисовке контекст не теряется.
+    print(getContextRuntimeType());
     return Container(
       child: Center(
         child: Text('Hello!\nI am\nstateful.'),


### PR DESCRIPTION
1. Переименуйте файл main.dart в start.dart. Запустите проект. Почему результат именно таков?
> flutter run возвращает ошибку: Target file "lib\main.dart" not found. потому что в настройках flutter по умолчанию указан main.dart как файл для запуска.

2. Задайте поле title. Запустите на Android. Где отобразится значение этого поля?
> В эмуляторе android - нигде не отображается, видимо зависит от версии sdk. А по идее должен отобразиться в списке приложений в заголовке приложения 

3. В вашем Stateless виджет создайте функцию, которая будет возвращать context.runtimeType. Функция должна быть без аргументов. Получится ли ее реализовать в данном виджете?

> Нет не получится. Ошибка: 
> `Error: The getter 'context' isn't defined for the class 'MyFirstStatelessWidget'.`

4. Проделайте предыдущий пункт в рамках Stateful. В чем разница?

> Тут получилось. Разница в том что базовый State содержит геттер get context.